### PR TITLE
fix: use`.mts` extension for imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "./scripts/deploy.sh",
     "typecheck": "tsc --skipLibCheck --noEmit",
     "watch": "nodemon --exec tsx src/main.ts",
-    "dev": "tsx src/main.ts",
+    "dev": "tsx src/main.mts",
     "format": "eslint --fix src/",
     "lint": "eslint src/",
     "rollback": "./scripts/rollback.sh",

--- a/src/main.mts
+++ b/src/main.mts
@@ -1,4 +1,4 @@
-import "./utils";
+import "./utils.mts";
 
 import { LIB_AUTOMATION } from "@digital-alchemy/automation";
 import { CreateApplication, StringConfig } from "@digital-alchemy/core";


### PR DESCRIPTION
## 📬 Changes

Template doesn't run because `.mts` imports are needed.

- ...

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
